### PR TITLE
Add Arch Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,27 @@ Native Elementary OS translater app. Uses Yandex API.
 
 ![Screenshot](https://raw.githubusercontent.com/rapidfingers/translator/master/data/screenshots/screenshot1.png)
 
+# Install
+
+```
+git clone https://github.com/RapidFingers/Translator/
+cd Translator
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+make
+sudo make install
+```
+
+## Arch Linux
+Arch Linux users can find Translator under the name [translator-git](https://aur.archlinux.org/packages/translator-git/) in the **AUR**:
+
+`$ aurman -S translator-git`
+
 # Donate
 
 <iframe frameborder="0" allowtransparency="true" scrolling="no" src="https://money.yandex.ru/embed/donate.xml?account=410013012437926&quickpay=donate&payment-type-choice=on&default-sum=100&targets=For+develop&target-visibility=on&project-name=Translator&project-site=&button-text=01&successURL=" width="439" height="117"></iframe>
 
-# MIT License
+## MIT License
 Copyright 2017 Grabli66
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
Arch Linux Support

I will support your application in Arch Linux.

Please add a section containing the following instruction:

## Arch Linux
Arch Linux users can find Translator under the name [translator-git](https://aur.archlinux.org/packages/translator-git/) in the **AUR**:

`$ aurman -S translator-git`

PS: I added your donation link in package description.