### PR TITLE
#68 show error message in case text volume exceeded 

### DIFF
--- a/src/TranslatorService.vala
+++ b/src/TranslatorService.vala
@@ -22,6 +22,7 @@ public class TranslateService : AsyncTaskExecuter {
     var data = new Gee.ArrayList<string>();
 
     if (root != null) {
+        this.CheckForError(root);
         var sentences = root.get_array_member("text");
 
         if (sentences != null) {
@@ -45,5 +46,12 @@ public class TranslateService : AsyncTaskExecuter {
     _to = to;
     _text = text;
     Run();
+  }
+
+  private void CheckForError(Json.Object response) throws TranslatorError {
+    if (response.has_member ("code") && response.has_member ("message")) {
+        string error_message = response.get_member("message").get_string();
+        throw new TranslatorError.TranslatedVolumeExceeded(error_message);
+    }
   }
 }

--- a/src/utils/TranslatorError.vala
+++ b/src/utils/TranslatorError.vala
@@ -1,5 +1,6 @@
 /// Exceptions
 public errordomain TranslatorError {
     /// No connection error
-    NoConnection;
+    NoConnection,
+    TranslatedVolumeExceeded;
 }


### PR DESCRIPTION
Yandex API is limited for translated text in free version: https://yandex.com/legal/translate_api/ 

It is useful to show the error message to the user in these cases. Otherwise nothing happens and no translation is showed. This pull request refers to #68 